### PR TITLE
Adds ability to unlock multiple accounts

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var bip39 = require("bip39");
 var hdkey = require('ethereumjs-wallet/hdkey');
 var ProviderEngine = require("web3-provider-engine");
 var FiltersSubprovider = require('web3-provider-engine/subproviders/filters.js');
-var WalletSubprovider = require('web3-provider-engine/subproviders/wallet.js');
 var HookedSubprovider = require('web3-provider-engine/subproviders/hooked-wallet.js');
 var Web3Subprovider = require("web3-provider-engine/subproviders/web3.js");
 var Web3 = require("web3");
@@ -42,7 +41,6 @@ function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses
       cb(null, rawTx);
     }
   }));
-  // this.engine.addProvider(new WalletSubprovider(this.wallets[this.addresses[0]], {}));
   this.engine.addProvider(new FiltersSubprovider());
   this.engine.addProvider(new Web3Subprovider(new Web3.providers.HttpProvider(provider_url)));
   this.engine.start(); // Required by the provider engine.

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses
   this.wallets = {};
   this.addresses = [];
 
-  for (let i = 0; i < num_addresses; i++){
+  for (let i = address_index; i < address_index + num_addresses; i++){
     var wallet = this.hdwallet.derivePath(this.wallet_hdpath + i).getWallet();
     var addr = '0x' + wallet.getAddress().toString('hex');
     this.addresses.push(addr);

--- a/index.js
+++ b/index.js
@@ -3,42 +3,33 @@ var hdkey = require('ethereumjs-wallet/hdkey');
 var ProviderEngine = require("web3-provider-engine");
 var FiltersSubprovider = require('web3-provider-engine/subproviders/filters.js');
 var WalletSubprovider = require('web3-provider-engine/subproviders/wallet.js');
+var HookedSubprovider = require('web3-provider-engine/subproviders/hooked-wallet.js');
 var Web3Subprovider = require("web3-provider-engine/subproviders/web3.js");
 var Web3 = require("web3");
 
-function HDWalletProvider(mnemonics, provider_url, address_index) {
-  var self = this;
-
-  // 'mnemonics' can either be a single string or an array of strings.
-  if (typeof mnemonics == 'string') { this.mnemonics = [ mnemonics ]; }
-  else { this.mnemonics = mnemonics; }
-
-  this.hdwallets = [];
-  // Create a hdwallet instance for each mnemonic.
-  this.mnemonics.forEach(function(m) {
-    // if (this.hdwallets === undefined) { this.hdwallets = []; }
-    self.hdwallets.push(hdkey.fromMasterSeed(bip39.mnemonicToSeed(m)));
-  })
-
-  // Start a ProviderEngine and add a SubProvider for each wallet supplied.
-  this.engine = new ProviderEngine();
-  // Use the address index across all provided wallets.
-  if (address_index == null) {
-    address_index = 0;
-  }
+function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses=1) {
+  this.mnemonic = mnemonic;
+  this.hdwallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(mnemonic));
   this.wallet_hdpath = "m/44'/60'/0'/0/";
+  this.wallets = {};
+  this.addresses = [];
 
-  this.hdwallets.forEach(function(w, i) {
-    // add the subprovider
-    var wallet = w.derivePath(self.wallet_hdpath + address_index).getWallet();
-    self.engine.addProvider(new WalletSubprovider(wallet, {}));
-    // Save the wallet/address if this is the first one
-    if (i == 0) {
-      self.wallet = wallet;
-      self.address =  "0x" + wallet.getAddress().toString("hex");
+  for (let i = 0; i < num_addresses; i++){
+    var wallet = this.hdwallet.derivePath(this.wallet_hdpath + i).getWallet();
+    var addr = wallet.getAddress().toString('hex');
+    this.addresses.push(addr);
+    this.wallets[addr] = wallet;
+  }
+
+  this.engine = new ProviderEngine();
+  this.engine.addProvider(new HookedSubprovider({
+    getAccounts: function(cb) { cb(null, this.addresses) },
+    getPrivateKey: function(address, cb) {
+      if (!this.wallets[address]) { return cb('Account not found'); }
+      else { cb(null, wallets[address].getPrivateKey().toString('hex')); }
     }
-  })
-  // Add the other SubProviders
+  }));
+  // this.engine.addProvider(new WalletSubprovider(this.wallets[this.addresses[0]], {}));
   this.engine.addProvider(new FiltersSubprovider());
   this.engine.addProvider(new Web3Subprovider(new Web3.providers.HttpProvider(provider_url)));
   this.engine.start(); // Required by the provider engine.
@@ -52,8 +43,16 @@ HDWalletProvider.prototype.send = function() {
   return this.engine.send.apply(this.engine, arguments);
 };
 
-HDWalletProvider.prototype.getAddress = function() {
-  return this.address;
-};
+// returns the address of the given address_index, first checking the cache
+HDWalletProvider.prototype.getAddress = function(idx) {
+  console.log('getting addresses', this.addresses[0], idx)
+  if (!idx) { return this.addresses[0]; }
+  else { return this.addresses[idx]; }
+}
+
+// returns the addresses cache
+HDWalletProvider.prototype.getAddresses = function() {
+  return this.addresses;
+}
 
 module.exports = HDWalletProvider;

--- a/index.js
+++ b/index.js
@@ -6,20 +6,39 @@ var WalletSubprovider = require('web3-provider-engine/subproviders/wallet.js');
 var Web3Subprovider = require("web3-provider-engine/subproviders/web3.js");
 var Web3 = require("web3");
 
-function HDWalletProvider(mnemonic, provider_url, address_index) {
-  this.mnemonic = mnemonic;
-  this.hdwallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(mnemonic));
+function HDWalletProvider(mnemonics, provider_url, address_index) {
+  var self = this;
 
+  // 'mnemonics' can either be a single string or an array of strings.
+  if (typeof mnemonics == 'string') { this.mnemonics = [ mnemonics ]; }
+  else { this.mnemonics = mnemonics; }
+
+  this.hdwallets = [];
+  // Create a hdwallet instance for each mnemonic.
+  this.mnemonics.forEach(function(m) {
+    // if (this.hdwallets === undefined) { this.hdwallets = []; }
+    self.hdwallets.push(hdkey.fromMasterSeed(bip39.mnemonicToSeed(m)));
+  })
+
+  // Start a ProviderEngine and add a SubProvider for each wallet supplied.
+  this.engine = new ProviderEngine();
+  // Use the address index across all provided wallets.
   if (address_index == null) {
     address_index = 0;
   }
-
   this.wallet_hdpath = "m/44'/60'/0'/0/";
-  this.wallet = this.hdwallet.derivePath(this.wallet_hdpath + address_index).getWallet();
-  this.address = "0x" + this.wallet.getAddress().toString("hex");
 
-  this.engine = new ProviderEngine();
-  this.engine.addProvider(new WalletSubprovider(this.wallet, {}));
+  this.hdwallets.forEach(function(w, i) {
+    // add the subprovider
+    var wallet = w.derivePath(self.wallet_hdpath + address_index).getWallet();
+    self.engine.addProvider(new WalletSubprovider(wallet, {}));
+    // Save the wallet/address if this is the first one
+    if (i == 0) {
+      self.wallet = wallet;
+      self.address =  "0x" + wallet.getAddress().toString("hex");
+    }
+  })
+  // Add the other SubProviders
   this.engine.addProvider(new FiltersSubprovider());
   this.engine.addProvider(new Web3Subprovider(new Web3.providers.HttpProvider(provider_url)));
   this.engine.start(); // Required by the provider engine.

--- a/index.js
+++ b/index.js
@@ -20,9 +20,9 @@ function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses
     var addr = '0x' + wallet.getAddress().toString('hex');
     this.addresses.push(addr);
     this.wallets[addr] = wallet;
+    console.log(wallet.getPrivateKey().toString('hex'))
   }
 
-  console.log('this.addresses!', this.addresses)
   const tmp_accounts = this.addresses;
   const tmp_wallets = this.wallets;
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,6 @@ function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses
     var addr = '0x' + wallet.getAddress().toString('hex');
     this.addresses.push(addr);
     this.wallets[addr] = wallet;
-    console.log(wallet.getPrivateKey().toString('hex'))
   }
 
   const tmp_accounts = this.addresses;
@@ -33,12 +32,10 @@ function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses
       if (!tmp_wallets[address]) { return cb('Account not found'); }
       else { cb(null, tmp_wallets[address].getPrivateKey().toString('hex')); }
     },
-    signTransaction: function(txParams, cb, address) {
-      let pkey = tmp_wallets[tmp_accounts[0]].getPrivateKey();
-      if (address) {
-        if (tmp_wallets[address]) { pkey = tmp_wallets[address].getPrivateKey(); }
-        else { cb('Account not found'); }
-      }
+    signTransaction: function(txParams, cb) {
+      let pkey;
+      if (tmp_wallets[txParams.from]) { pkey = tmp_wallets[txParams.from].getPrivateKey(); }
+      else { cb('Account not found'); }
       var tx = new Transaction(txParams);
       tx.sign(pkey);
       var rawTx = '0x' + tx.serialize().toString('hex');


### PR DESCRIPTION
I needed to deploy to a remote node (via INFURA) and to test transactions with multiple accounts. Using `WalletSubprovider` does not allow for this -- this PR switches that subprovider for `HookedSubprovider`, which is much more flexible.

This is derived from https://github.com/trufflesuite/truffle-hdwallet-provider/pull/3 but does not require any changes to `provider-engine`.