### PR TITLE
add password and correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # truffle-hdwallet-provider
-HD Wallet-enabled Web3 provider. Use it to sign transactions for addresses derived from a 12-word mnemonic.
+HD Wallet-enabled Web3 provider. Use it to sign transactions for addresses derived from a 1-24 word mnemonic.
 
 ## Install
 
@@ -24,10 +24,10 @@ By default, the `HDWalletProvider` will use the address of the first address tha
 
 Parameters:
 
-- `mnemonic`: `string`. 12 word mnemonic which addresses are created from.
+- `mnemonic`: `string`. 1-24 word mnemonic which addresses are created from. (checksum not currently enforced)
 - `provider_uri`: `string`. URI of Ethereum client to send all other non-transaction-related Web3 requests.
 - `address_index`: `number`, optional. If specified, will tell the provider to manage the address at the index specified. Defaults to the first address (index `0`).
-
+- `password`: `string`, optional. If specified, will derive seed with addition of said bip39 passphrase.
 ## Truffle Usage
 
 You can easily use this within a Truffle configuration. For instance:

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ var Web3Subprovider = require("web3-provider-engine/subproviders/web3.js");
 var Web3 = require("web3");
 var Transaction = require('ethereumjs-tx');
 
-function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses=1) {
+function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses=1, password='') {
   this.mnemonic = mnemonic;
-  this.hdwallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(mnemonic));
+  this.hdwallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(mnemonic, password));
   this.wallet_hdpath = "m/44'/60'/0'/0/";
   this.wallets = {};
   this.addresses = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-hdwallet-provider",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "HD Wallet-enabled Web3 provider",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- adds bip39 passphrase option for HD wallet
- corrects some points in README and notes that the mnemonic checksums
are not enforced (should maybe have an option to enforce them).
- incremented version to 0.0.4