### PR TITLE
Document hidden param for multiple addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ var provider = new HDWalletProvider(mnemonic, "http://localhost:8545");
 var provider = new HDWalletProvider(mnemonic, "http://localhost:8545", 5);
 ```
 
-By default, the `HDWalletProvider` will use the address of the first address that's generated from the mnemonic. If you pass in a specific index, it'll use that address instead. Currently, the `HDWalletProvider` manages only one address at a time, but it can be easily upgraded to manage (i.e., "unlock") multiple addresses.
+By default, the `HDWalletProvider` will use the address of the first address that's generated from the mnemonic. If you pass in a specific index, it'll use that address instead.
 
 Parameters:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Parameters:
 - `mnemonic`: `string`. 12 word mnemonic which addresses are created from.
 - `provider_uri`: `string`. URI of Ethereum client to send all other non-transaction-related Web3 requests.
 - `address_index`: `number`, optional. If specified, will tell the provider to manage the address at the index specified. Defaults to the first address (index `0`).
+- `num_addresses`: `number`, optional. If specified, will tell the provider to create the specified number of addresses. Defaults to `1`.
 
 ## Truffle Usage
 


### PR DESCRIPTION
This updates the parameters documentation to include [`num_addresses`](https://github.com/trufflesuite/truffle-hdwallet-provider/blob/master/index.js#L10). The prior instruction caused some confusion [here](https://github.com/OriginProtocol/origin-js/issues/156).