### PR TITLE
Support importing one or more private keys with indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.idea

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ var provider = new HDWalletProvider("3f841bf589fdf83a521e55d51afddc34fa65351161e
 
 // Or, pass an array of private keys, and optionally use a certain subset of addresses
 var privateKeys = [
-  '3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580',
-  '9549f39decea7b7504e15572b2c6a72766df0281cea22bd1a3bc87166b1ca290',
+  "3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580",
+  "9549f39decea7b7504e15572b2c6a72766df0281cea22bd1a3bc87166b1ca290",
 ];
 var provider = new HDWalletProvider(privateKeys, "http://localhost:8545", 0, 2); //start at address_index 0 and load both addresses
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Instead of a mnemonic, you can alternatively provide a private key or array of p
 
 ```javascript
 var HDWalletProvider = require("truffle-hdwallet-provider");
-var provider = new HDWalletProvider("3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580", "http://localhost:8545"); //load single private key as string
+//load single private key as string
+var provider = new HDWalletProvider("3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580", "http://localhost:8545");
 
 // Or, pass an array of private keys, and optionally use a certain subset of addresses
 var privateKeys = [

--- a/README.md
+++ b/README.md
@@ -20,14 +20,31 @@ var provider = new HDWalletProvider(mnemonic, "http://localhost:8545");
 var provider = new HDWalletProvider(mnemonic, "http://localhost:8545", 5);
 ```
 
-By default, the `HDWalletProvider` will use the address of the first address that's generated from the mnemonic. If you pass in a specific index, it'll use that address instead. Currently, the `HDWalletProvider` manages only one address at a time, but it can be easily upgraded to manage (i.e., "unlock") multiple addresses.
+By default, the `HDWalletProvider` will use the address of the first address that's generated from the mnemonic. If you pass in a specific index, it'll use that address instead.
 
 Parameters:
 
 - `mnemonic`: `string`. 12 word mnemonic which addresses are created from.
 - `provider_uri`: `string`. URI of Ethereum client to send all other non-transaction-related Web3 requests.
-- `address_index`: `number`, optional. If specified, will tell the provider to manage the address at the index specified. Defaults to the first address (index `0`).
+- `address_index`: `number`, optional. If specified, will tell the provider to manage the address or addresses starting at the index specified. Defaults to the first address (index `0`).
+- `num_addresses`: `number`, optional. If specified, will tell the provider to manage the specified number of addresses. Defaults to `1`.
 
+### Private Keys
+
+Instead of a mnemonic, you can alternatively provide a private key or array of private keys as the first parameter. When providing an array, `address_index` and `num_addresses` are fully supported.
+
+```javascript
+var HDWalletProvider = require("truffle-hdwallet-provider");
+var provider = new HDWalletProvider("3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580", "http://localhost:8545"); //load single private key as string
+
+// Or, pass an array of private keys, and optionally use a certain subset of addresses
+var privateKeys = [
+  '3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580',
+  '9549f39decea7b7504e15572b2c6a72766df0281cea22bd1a3bc87166b1ca290',
+];
+var provider = new HDWalletProvider(privateKeys, "http://localhost:8545", 0, 2); //start at address_index 0 and load both addresses
+```
+**NOTE: This is just an example. NEVER hard code production/mainnet private keys in your code or commit them to git. They should always be loaded from environment variables or a secure secret management system.**
 ## Truffle Usage
 
 You can easily use this within a Truffle configuration. For instance:

--- a/index.js
+++ b/index.js
@@ -10,14 +10,18 @@ var Wallet = require('ethereumjs-wallet');
 var EthUtil = require('ethereumjs-util');
 
 function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses=1) {
-  if (mnemonic.indexOf(' ') === -1) {
-    var privateKey = new Buffer(mnemonic, 'hex');
-    if (EthUtil.isValidPrivate(privateKey)) {
-      var wallet = Wallet.fromPrivateKey(privateKey);
-      var address = wallet.getAddressString();
-      this.addresses = [address];
-      this.wallets = {};
-      this.wallets[address] = wallet;
+  if (mnemonic.indexOf(' ') === -1 || Array.isArray(mnemonic)) {
+    var privateKeys = Array.isArray(mnemonic) ? mnemonic : [mnemonic];
+    this.wallets = {};
+    this.addresses = [];
+    for (let i = address_index; i < address_index + num_addresses; i++){
+      var privateKey = new Buffer(privateKeys[i], 'hex');
+      if (EthUtil.isValidPrivate(privateKey)) {
+        var wallet = Wallet.fromPrivateKey(privateKey);
+        var address = wallet.getAddressString();
+        this.addresses.push(address);
+        this.wallets[address] = wallet;
+      }
     }
   } else {
     this.mnemonic = mnemonic;

--- a/test/provider.js
+++ b/test/provider.js
@@ -40,6 +40,7 @@ describe("HD Wallet Provider", function(done) {
     web3.setProvider(provider);
 
     const addresses = provider.getAddresses();
+    assert.equal(addresses[0], '0xc515db5834d8f110eee96c3036854dbf1d87de2b');
     addresses.forEach((address) => {
       assert(EthUtil.isValidAddress(address), 'invalid address');
     });

--- a/test/provider.js
+++ b/test/provider.js
@@ -1,7 +1,7 @@
 const Ganache = require('ganache-core');
 const assert = require('assert');
 const WalletProvider = require('../index.js');
-const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
+const EthUtil = require('ethereumjs-util');
 
 describe("HD Wallet Provider", function(done) {
   var Web3 = require('web3');
@@ -16,11 +16,15 @@ describe("HD Wallet Provider", function(done) {
   });
 
   after(done => {
-    provider.engine.stop();
     setTimeout(() => server.close(done), 2000); // :/
-  })
+  });
 
-  it('provides', function(done){
+  afterEach(() => {
+    provider.engine.stop();
+  });
+
+  it('provides for a mnemonic', function(done){
+    const mnemonic = 'candy maple cake sugar pudding cream honey rich smooth crumble sweet treat';
     provider = new WalletProvider(mnemonic, `http://localhost:${port}`);
     web3.setProvider(provider);
 
@@ -28,6 +32,54 @@ describe("HD Wallet Provider", function(done) {
       assert(number === 0);
       done();
     });
-  })
+  });
+
+  it('provides for a private key', function(done){
+    const privateKey = '3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580'; //random valid private key generated with ethkey
+    provider = new WalletProvider(privateKey, `http://localhost:${port}`);
+    web3.setProvider(provider);
+
+    const addresses = provider.getAddresses();
+    addresses.forEach((address) => {
+      assert(EthUtil.isValidAddress(address), 'invalid address');
+    });
+
+
+    web3.eth.getBlockNumber((err, number) => {
+      assert(number === 0);
+      done();
+    });
+  });
+
+  it('provides for an array of private keys', function(done){
+    const privateKeys = [
+      '3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580',
+      '9549f39decea7b7504e15572b2c6a72766df0281cea22bd1a3bc87166b1ca290',
+    ];
+
+    const privateKeysByAddress = {
+      '0xc515db5834d8f110eee96c3036854dbf1d87de2b': '3f841bf589fdf83a521e55d51afddc34fa65351161eead24f064855fc29c9580',
+      '0xbd3366a0e5d2fb52691e3e08fabe136b0d4e5929': '9549f39decea7b7504e15572b2c6a72766df0281cea22bd1a3bc87166b1ca290',
+    };
+
+
+    provider = new WalletProvider(privateKeys, `http://localhost:${port}`, 0, privateKeys.length); //pass in num_addresses to load full array
+    web3.setProvider(provider);
+
+    const addresses = provider.getAddresses();
+    assert.equal(addresses.length, privateKeys.length, 'incorrect number of wallets derived');
+    addresses.forEach((address) => {
+      assert(EthUtil.isValidAddress(address), 'invalid address');
+      const privateKey = new Buffer(privateKeysByAddress[address], 'hex');
+      const expectedAddress = `0x${EthUtil.privateToAddress(privateKey).toString('hex')}`;
+      assert.equal(address, expectedAddress, 'incorrect address for private key');
+    });
+
+
+    web3.eth.getBlockNumber((err, number) => {
+      assert(number === 0);
+      done();
+    });
+  });
 });
 


### PR DESCRIPTION
This is inspired by some previous open PRs: #2, #25, and #32. It enables support for importing one or more wallet addresses using private keys instead of a mnemonic. It supports a single key as a string, or an array of keys. The difference between this PRs and previous is that this fully implements the current _HookedSubprovider_ interface and supports both the `address_index` and `num_addresses` options when passed an array. I have added updated documentation, both of this feature, and `num_addresses` generally, which is still undocumented in master. Also includes new and updated unit tests.