### PR TITLE
Issue #46: Add guide about terminating provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ var provider = new HDWalletProvider(mnemonic, "http://localhost:8545");
 
 // Or, alternatively pass in a zero-based address index.
 var provider = new HDWalletProvider(mnemonic, "http://localhost:8545", 5);
+
+// ...
+// Write your code here.
+// ...
+
+// At termination, `provider.engine.stop()' should be called to finish the process elegantly.
+provider.engine.stop();
 ```
 
 By default, the `HDWalletProvider` will use the address of the first address that's generated from the mnemonic. If you pass in a specific index, it'll use that address instead. Currently, the `HDWalletProvider` manages only one address at a time, but it can be easily upgraded to manage (i.e., "unlock") multiple addresses.
@@ -32,6 +39,8 @@ Parameters:
 - `mnemonic`: `string`. 12 word mnemonic which addresses are created from.
 - `provider_uri`: `string`. URI of Ethereum client to send all other non-transaction-related Web3 requests.
 - `address_index`: `number`, optional. If specified, will tell the provider to manage the address at the index specified. Defaults to the first address (index `0`).
+
+
 
 ## Truffle Usage
 


### PR DESCRIPTION
Addresses #46 
It fixes Readme.md to guide users to call `provider.engine.stop()` explicitly.