### PR TITLE
chore: update README for usage with tuffle.js file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ module.exports = {
       network_id: "*" // Match any network id
     },
     ropsten: {
-      provider: new HDWalletProvider(mnemonic, "https://ropsten.infura.io/"),
-      network_id: 3
+      // must be a thunk, otherwise truffle commands may hang in CI
+      provider: () =>
+        new HDWalletProvider(mnemonic, "https://ropsten.infura.io/"),
+      network_id: '3',
     }
   }
 };


### PR DESCRIPTION
## What
Update the README to encourage using HDWalletProvider as a thunk value in truffle.js config

## Why
Had an issue during our CI test runs where having the HDWalletProvider in any network key in the `truffle.js` file would cause a hanging process during `truffle migrate`

## Related
https://github.com/trufflesuite/truffle-migrate/issues/14#issuecomment-399462449