### PR TITLE
Add truffle 4 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "devDependencies": {
     "ganache-core": "^2.1.0",
     "mocha": "^5.1.1"
+  },
+  "peerDependencies": {
+    "truffle": "4.x"
   }
 }


### PR DESCRIPTION
This version of the wallet doesn't work with truffle V5 / web3 1.0 - this should trigger a warning. 