### PR TITLE
Pin ethereumjs-wallet to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/trufflesuite/truffle-hdwallet-provider#readme",
   "dependencies": {
     "bip39": "^2.2.0",
-    "ethereumjs-wallet": "^0.6.0",
+    "ethereumjs-wallet": "0.6.0",
     "web3": "^0.18.2",
     "web3-provider-engine": "^14.0.5"
   },


### PR DESCRIPTION
#54 

[Work](https://github.com/ethereumjs/ethereumjs-wallet/commits/master) published at `ethereumjs-wallet` yesterday broke truffle-hdwallet. Just stopping the bleeding here.