### PR TITLE
Fix error signining transactions when address is not lowercase

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses
     },
     signTransaction: function(txParams, cb) {
       let pkey;
-      if (tmp_wallets[txParams.from]) { pkey = tmp_wallets[txParams.from].getPrivateKey(); }
+      const from = txParams.from.toLowerCase()
+      if (tmp_wallets[from]) { pkey = tmp_wallets[from].getPrivateKey(); }
       else { cb('Account not found'); }
       var tx = new Transaction(txParams);
       tx.sign(pkey);


### PR DESCRIPTION
In the transaction signing, it just assumes the address is in lowercase. When it match the from of the transaction with the keys of the object `this.wallets`, it doesn't necessarily work.

Addresses doesn't need to be lowercase, in fact, if we want use the Mixed-case checksum address encoding, it won't work: 

See: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md