### PR TITLE
Add nonce tracking 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can use this provider wherever a Web3 provider is needed, not just in Truffl
 
 ```javascript
 var HDWalletProvider = require("truffle-hdwallet-provider");
-var mnemonic = "opinion destroy betray ..."; // 12 word mnemonic
+var mnemonic = "mountains supernatural bird..."; // 12 word mnemonic
 var provider = new HDWalletProvider(mnemonic, "http://localhost:8545");
 
 // Or, alternatively pass in a zero-based address index.
@@ -29,9 +29,13 @@ By default, the `HDWalletProvider` will use the address of the first address tha
 
 Parameters:
 
-- `mnemonic`: `string`. 12 word mnemonic which addresses are created from.
-- `provider_uri`: `string`. URI of Ethereum client to send all other non-transaction-related Web3 requests.
-- `address_index`: `number`, optional. If specified, will tell the provider to manage the address at the index specified. Defaults to the first address (index `0`).
+| Parameter | Type | Default | Description |
+| ------ | ---- | ------- | ----------- |
+| mnemonic | *string* | null | <required> 12 word mnemonic which addresses are created from. |
+| provider_uri | *string* | null | <required> URI of Ethereum client to send all other non-transaction-related Web3 requests |
+| address_index | *number* | 0 | <optional> If specified, will tell the provider to manage the address at the index specified |
+| num_addresses | *number* | 1 | <optional> If specified, will create `number` addresses when instantiated |
+| shareNonce | *boolean* | true | <optional> If false, a new WalletProvider will track its own nonce-state |
 
 ## Truffle Usage
 
@@ -41,7 +45,7 @@ truffle.js
 ```javascript
 var HDWalletProvider = require("truffle-hdwallet-provider");
 
-var mnemonic = "opinion destroy betray ...";
+var mnemonic = "mountains supernatural bird ...";
 
 module.exports = {
   networks: {

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var bip39 = require("bip39");
 var hdkey = require('ethereumjs-wallet/hdkey');
 var ProviderEngine = require("web3-provider-engine");
 var FiltersSubprovider = require('web3-provider-engine/subproviders/filters.js');
+var NonceSubProvider = require('web3-provider-engine/subproviders/nonce-tracker.js');
 var HookedSubprovider = require('web3-provider-engine/subproviders/hooked-wallet.js');
 var ProviderSubprovider = require("web3-provider-engine/subproviders/provider.js");
 var Web3 = require("web3");
@@ -41,6 +42,8 @@ function HDWalletProvider(mnemonic, provider_url, address_index=0, num_addresses
       cb(null, rawTx);
     }
   }));
+
+  this.engine.addProvider(new NonceSubProvider());
   this.engine.addProvider(new FiltersSubprovider());
   this.engine.addProvider(new ProviderSubprovider(new Web3.providers.HttpProvider(provider_url)));
   this.engine.start(); // Required by the provider engine.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-hdwallet-provider",
-  "version": "0.0.6",
+  "version": "0.0.7-beta.0",
   "description": "HD Wallet-enabled Web3 provider",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#65 
[truffle 1079](https://github.com/trufflesuite/truffle/issues/1079)
[truffle 763](https://github.com/trufflesuite/truffle/issues/763) 

Addresses:
`nonce too low`
`replacement transaction underpriced`

These occur frequently using Infura / load balanced nets. Detailed reproduction and explanation in #65. 

[Postscript]
All credit for this goes to Zeppelin engineer @spalladino who diagnosed the problem and mapped out some strategies to address it. In the end it looks like we only have a partial solution here. . . it may fix truffle 763 but truffle 1079 (firing a series of simultaneous txs) will still be a problem. #65 has additional info and a work-around that Zeppelin is using to do this successfully.  