### PR TITLE
Make dpath configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Parameters:
 | address_index | *number* | 0 | <optional> If specified, will tell the provider to manage the address at the index specified |
 | num_addresses | *number* | 1 | <optional> If specified, will create `number` addresses when instantiated |
 | shareNonce | *boolean* | true | <optional> If false, a new WalletProvider will track its own nonce-state |
+| networkId | *number* | 60 | <optional> If specified, will tell the provider to derive addresses using it in the dpath |
 
 ## Truffle Usage
 

--- a/index.js
+++ b/index.js
@@ -20,11 +20,12 @@ function HDWalletProvider(
   provider_url,
   address_index=0,
   num_addresses=1,
-  shareNonce=true
+  shareNonce=true,
+  networkId=60
 ) {
   this.mnemonic = mnemonic;
   this.hdwallet = hdkey.fromMasterSeed(bip39.mnemonicToSeed(mnemonic));
-  this.wallet_hdpath = "m/44'/60'/0'/0/";
+  this.wallet_hdpath = `m/44'/${networkId}'/0'/0/`;
   this.wallets = {};
   this.addresses = [];
 


### PR DESCRIPTION
`truffle-hdwallet-provider` is hardcoded to derive only Ethereum addresses. Other networks, RSK for example, derive their addresses using different dpaths.
This PR adds a new parameter `networkId` to the provider constructor (with ethereum `60` as default) and uses it to make dpath configurable.