### PR TITLE
Support hdwallet signing on existing providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Parameters:
 | Parameter | Type | Default | Description |
 | ------ | ---- | ------- | ----------- |
 | mnemonic | *string* | null | <required> 12 word mnemonic which addresses are created from. |
-| provider_uri | *string* | null | <required> URI of Ethereum client to send all other non-transaction-related Web3 requests |
+| provider | *string* / *object* | null | <required> URI or Ethereum client to send all other non-transaction-related Web3 requests |
 | address_index | *number* | 0 | <optional> If specified, will tell the provider to manage the address at the index specified |
 | num_addresses | *number* | 1 | <optional> If specified, will create `number` addresses when instantiated |
 | shareNonce | *boolean* | true | <optional> If false, a new WalletProvider will track its own nonce-state |

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var singletonNonceSubProvider = new NonceSubProvider();
 
 function HDWalletProvider(
   mnemonic,
-  provider_url,
+  provider,
   address_index=0,
   num_addresses=1,
   shareNonce=true
@@ -61,7 +61,11 @@ function HDWalletProvider(
     : this.engine.addProvider(singletonNonceSubProvider);
 
   this.engine.addProvider(new FiltersSubprovider());
-  this.engine.addProvider(new ProviderSubprovider(new Web3.providers.HttpProvider(provider_url)));
+  if (typeof provider === 'string') {
+    this.engine.addProvider(new ProviderSubprovider(new Web3.providers.HttpProvider(provider)));
+  } else {
+    this.engine.addProvider(new ProviderSubprovider(provider));
+  }
   this.engine.start(); // Required by the provider engine.
 };
 


### PR DESCRIPTION
This change supports configuration of the gateway provider, either to upgrade it to a websocket connection, or to configure timeouts or other options on the underlying provider.