### PR TITLE
Deprecate this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # truffle-hdwallet-provider
 HD Wallet-enabled Web3 provider. Use it to sign transactions for addresses derived from a 12-word mnemonic.
 
+### :warning: This repo is deprecated :warning:
+**Truffle has moved all modules to a monorepo at [trufflesuite/truffle](https://github.com/trufflesuite/truffle). See you over there!**
+
+-----------------------
+
 ## Install
 
 ```


### PR DESCRIPTION
Presumably, this repo has been **deprecated** ([as truffle-contract](https://github.com/trufflesuite/truffle-contract) has for example)

I got navigated here through the npm registry and was confused for some time as to why the package version here was so much lower the *truffle-hdwallet-provider* version in my `package.json`.

~~I'll be opening~~ **I have opened** [a subsequent PR](https://github.com/trufflesuite/truffle/pull/1693) to to update the *repository* fields in the new mono-repo packages' `package.json`s.

I'd suggest that you also **Archive** this repo as well.